### PR TITLE
Distinción entre opciones obligatorias y opcionales en Config

### DIFF
--- a/src/Config.java
+++ b/src/Config.java
@@ -61,13 +61,18 @@ public class Config {
 
 	/** Obtiene la opcion del hashMap de configuracion. Si no existe devuelve "".
 	 *  @param option Opcion de configuracion a buscar.
+	 *  @param required Indica si la opción es obligatoria (true) u opcional (false).
 	 *  @return Valor que tiene en el hashMap o "". */
-	public static String get(String option){
+	public static String get(String option, boolean required){
 		
-		if (map.get(option) == null)
+		if (map.get(option) == null && required)
 			System.out.println("["+new Timestamp(new Date().getTime())+"] No se ha encontrado el campo "+option+" en el archivo de configuración. Compruebe que existe o si no ejecute cat2osm con el parámetro -ui para crear un nuevo archivo de configuración.");
 		
 		return (map.get(option) == null) ? "" : map.get(option);
+	}
+	
+	public static String get(String option) {
+		return get(option, true);
 	}
 
 

--- a/src/Main.java
+++ b/src/Main.java
@@ -135,10 +135,10 @@ public class Main {
 		}
 		
 		// Si va a leer ELEMTEX comprueba si existe fichero de reglas
-		if (archivo.equals("*") || archivo.equals("ELEMTEX")) {
-			if (!Config.get("ElemtexRules").equals("") && new File(Config.get("ElemtexRules")).exists()) {
-				System.out.println(Config.get("ElemtexRules"));
-				new Rules(Config.get("ElemtexRules"));
+		if (archivo.equals("ELEMTEX")) {
+			if (!Config.get("ElemtexRules", false).equals("") && new File(Config.get("ElemtexRules", false)).exists()) {
+				System.out.println("["+new Timestamp(new Date().getTime())+"] Leyendo archivo de reglas " + Config.get("ElemtexRules", false));
+				new Rules(Config.get("ElemtexRules", false));
 			}
 		}
 


### PR DESCRIPTION
Hola.

Al poner la opción ElemtexRules comentada en el fichero de configuración, como el programa siempre va a buscarla, sale un mensaje de error diciendo que no la encuentra que lleva a confusión. Lo he evitado pasando un parámetro boolean al get de Config para indicar si la opción es obligatoria o no. Si se llama a get como siempre asume true.

Por favor, mira si está pasando algo con el archivo .jar. La última versión descargada no incluye la cuestión de las reglas. La está ignorando completamente.

Saludos
