### PR TITLE
Guarda los resultados comprimidos con GZIP

### DIFF
--- a/src/Cat2Osm.java
+++ b/src/Cat2Osm.java
@@ -1079,6 +1079,7 @@ public class Cat2Osm {
 						}
 			}
 		}
+		bufRdr.close();
 	}
 
 
@@ -1159,6 +1160,7 @@ public class Cat2Osm {
 						}
 			}
 		}
+		bufRdr.close();
 	}
 
 

--- a/src/Cat2Osm.java
+++ b/src/Cat2Osm.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.zip.GZIPOutputStream;
 
 import org.geotools.geometry.jts.JTSFactoryFinder;
 
@@ -809,11 +810,12 @@ public class Cat2Osm {
 
 		// Borrar archivo con el mismo nombre si existe, porque sino concatenaria el nuevo
 		new File(path + "/" + folder + "/" + filename +".osm").delete();
+		new File(path + "/" + folder + "/" + filename +".osm.gz").delete();
 
 		// Archivo al que se le concatenan los nodos, ways y relations
-		String fstreamOsm = path + "/" + folder + "/" + filename + ".osm";
+		String fstreamOsm = path + "/" + folder + "/" + filename + ".osm.gz";
 		// Indicamos que el archivo se codifique en UTF-8
-		BufferedWriter outOsm = new BufferedWriter( new OutputStreamWriter (new FileOutputStream(fstreamOsm), "UTF-8"));
+		BufferedWriter outOsm = new BufferedWriter( new OutputStreamWriter (new GZIPOutputStream(new FileOutputStream(fstreamOsm)), "UTF-8"));
 
 		// Juntamos los archivos en uno, al de los nodos le concatenamos el de ways y el de relations
 		// Cabecera del archivo Osm

--- a/src/Cat2Osm.java
+++ b/src/Cat2Osm.java
@@ -2,10 +2,10 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import org.geotools.geometry.jts.JTSFactoryFinder;
@@ -998,8 +999,7 @@ public class Cat2Osm {
 	 */
 	public void catParser(String tipo, File cat, HashMap <String, List<Shape>> shapesTotales) throws IOException{
 
-		BufferedReader bufRdr = 
-				new BufferedReader(new InputStreamReader(new FileInputStream(cat), "ISO-8859-15"));
+		BufferedReader bufRdr = createCatReader(cat);
 		String line = null; // Para cada linea leida del archivo .cat
 
 		int tipoRegistrosBuscar = Integer.parseInt(Config.get("TipoRegistro"));
@@ -1093,7 +1093,7 @@ public class Cat2Osm {
 	 */
 	public void catUsosParser(String tipo, File cat, HashMap <String, List<Shape>> shapesTotales) throws IOException{
 
-		BufferedReader bufRdr  = new BufferedReader(new FileReader(cat));
+		BufferedReader bufRdr  = createCatReader(cat);
 		String line = null; // Para cada linea leida del archivo .cat
 
 		// Lectura del archivo .cat
@@ -1170,7 +1170,7 @@ public class Cat2Osm {
 	 */
 	public List<Cat> catParser(File f) throws IOException{
 
-		BufferedReader bufRdr  = new BufferedReader(new FileReader(f));
+		BufferedReader bufRdr = createCatReader(f);
 		String line = null;
 
 		List<Cat> l = new ArrayList<Cat>();
@@ -1187,6 +1187,14 @@ public class Cat2Osm {
 		}
 		bufRdr.close();
 		return l;
+	}
+	
+	private BufferedReader createCatReader(File archivoCat) throws IOException {
+		InputStream inputStream = new FileInputStream(archivoCat);
+		if (archivoCat.getName().toLowerCase().endsWith(".gz")){
+			inputStream = new GZIPInputStream(inputStream);
+		}
+		return new BufferedReader(new InputStreamReader(inputStream, "ISO-8859-15"));
 	}
 
 

--- a/src/CatExtractor.java
+++ b/src/CatExtractor.java
@@ -1,0 +1,54 @@
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.commons.io.IOUtils;
+
+
+
+public class CatExtractor {
+
+	public static void extract (String filename) throws IOException{
+		if (filename == null || "".equals(filename.trim())){
+			return;
+		}
+		File directorio = new File(filename);
+		File archivoZip = new File(directorio.getAbsolutePath() + ".zip");
+		if (directorio.exists() && directorio.isDirectory()) {
+			return;
+		}
+		if (archivoZip.exists()){
+			//System.out.println("Descomprimiendo el archivo de catastro " + archivoZip.getName());
+			directorio.mkdirs();
+			ZipInputStream zis = new ZipInputStream(new FileInputStream(archivoZip));
+			extract(directorio, zis);
+			zis.close();			
+		}
+	}
+	private static void extract (File directorio, ZipInputStream zis) throws IOException {
+		
+		ZipEntry entry = null;
+		while ( (entry = zis.getNextEntry()) != null) {
+			String nombre = entry.getName();
+			if (nombre.toLowerCase().endsWith(".zip")){
+				nombre = nombre.substring(0, nombre.indexOf('.'));
+				File subdirectorio = new File(directorio, nombre);
+				subdirectorio.mkdirs();
+				ZipInputStream contenido = new ZipInputStream(zis);
+				extract (subdirectorio, contenido);
+			}
+			else {
+				System.out.println("Descomprimiendo archivo " + nombre);
+				File archivo = new File(directorio, nombre);
+				OutputStream fos = new FileOutputStream(archivo);
+				IOUtils.copy(zis, fos);
+			}
+			zis.closeEntry();
+		}
+		
+	}
+}

--- a/src/CatProjectionReader.java
+++ b/src/CatProjectionReader.java
@@ -1,0 +1,106 @@
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class CatProjectionReader {
+	/**
+	 * Trata de autodectar el sistema de coordenadas de un archivo prj
+	 * @param directorio
+	 * @return
+	 */
+
+	public static String autodetectProjection(String directorio) {
+		File archivoPrj = buscarArchivoPrj(new File(directorio));
+		if (archivoPrj != null){
+			try {
+				return autodetectProjectionFromFile(archivoPrj);
+			} catch (IOException  e) {
+				e.printStackTrace();
+			}
+		}
+		return "";
+	}
+	
+	/**
+	 * Busca un archivo prj dentro de un directorio.
+	 * Devuelve el primero que encuentra
+	 * @param directorio
+	 * @return
+	 */
+	private static File buscarArchivoPrj(File directorio) {
+
+		
+		File[] contenidos = directorio.listFiles();
+		for (File archivo: contenidos) {
+			if (archivo.isDirectory()){
+				File buscado = buscarArchivoPrj(archivo);
+				if (buscado != null) {
+					return buscado;
+				}
+			}
+			if (archivo.isFile() && archivo.getName().toLowerCase().endsWith(".prj")){
+				return archivo;
+			}
+		}
+		return null;
+	}
+	/**
+	 * Lee un archivo prj y devuelve el código de sistema de coordenadas
+	 * @param archivo
+	 * @return
+	 * @throws IOException
+	 */
+	public static String autodetectProjectionFromFile(File archivo) throws IOException {
+		String contenido = readFile(archivo);
+		contenido = contenido.replaceAll("\",.*", "");
+		contenido = contenido.replaceAll(".*\"", "");
+		switch(contenido) {
+		// TODO Faltan más casos/codigos
+		case "ED_19950_UTM_Zone_29N": return "23029";
+		case "ED_19950_UTM_Zone_30N": return "23030";
+		case "ED_19950_UTM_Zone_31N": return "23031";
+		case "ETRS_1989_UTM_Zone_29N": return "25829";
+		case "ETRS_1989_UTM_Zone_30N": return "25830";
+		case "ETRS_1989_UTM_Zone_31N": return "25831";
+		
+		default: return "";
+		}
+
+	}
+	private static String readFile(File archivo) throws IOException {
+		String resultado = null;
+		BufferedReader reader = null;
+		try {
+			reader = new BufferedReader(new InputStreamReader(new FileInputStream(archivo)));
+			resultado = reader.readLine();
+		}
+		finally {
+			if (reader != null){
+				try {
+					reader.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+		return resultado;
+	}
+	/*
+	 * Así no funciona: o no lo soporta bien o requiere de configuración adicional
+	public static String autodetectProjectionFromFileGeoTools(File archivo) throws IOException, FactoryException {
+		FileInputStream inputStream = new FileInputStream(archivo);
+		FileChannel channel = inputStream.getChannel();
+
+		PrjFileReader reader = new PrjFileReader(channel);
+		inputStream.close();
+		CoordinateReferenceSystem crs = reader.getCoordinateReferenceSystem();
+		return crs.getName().getCode();
+	}
+	
+	public static void main (String[] args) throws IOException, FactoryException {
+		System.out.println(autodetectProjection("/home/alberto/cat2osm/moratinos/files/Moratinos/34_109_RA_2012-09-20_SHF"));
+	}
+	*/
+}

--- a/src/Config.java
+++ b/src/Config.java
@@ -1,74 +1,179 @@
-import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
 import java.sql.Timestamp;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
+import java.util.zip.ZipInputStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.h2.util.IOUtils;
 
 
 public class Config {
 
-	/** HashMap con la configuracion. */
-	private static HashMap<String,String> map = new HashMap<String,String>(20);
+	/** Properties con la configuracion. */
+	private static Properties configuration = new Properties();
 
-	/** Constructor. Abre el fichero y llena el hashMap con los datos.
-	 *  El fichero de texto plano con entradas del tipo key=value.
-	 *  Las lineas en blanco sera ignoradas asi como las lineas que
-	 *  comiencen por #.
-	 *  @param file Fichero de configuracion.*/
-	public Config(String file)
-	{
-		String[] aux; // Auxiliar para parsear las lineas
-		String   temp = null; // Temporal para recoger las lineas
-
-		File           f  = null;
-		FileReader     fr = null;
-		BufferedReader br = null;
-
-		try
-		{
-			f  = new File(file);
-			fr = new FileReader(f);
-			br = new BufferedReader(fr);
-
-			temp = br.readLine();
-			while (temp != null) // Mientras haya datos
-			{
-				// Ignora comentarios y lineas en blanco
-				if ((temp.length() != 0) && (temp.charAt(0) != '#'))
-				{
-					aux = temp.split("=");
-					String concat = aux[1];
-					for (int i = 2; i < aux.length; i++)
-						concat = concat + "=" + aux[i];
-					map.put(aux[0],concat);
+	
+	/**
+	 * Carga la configuración.
+	 * @param file archivo de configuracion.
+	 */
+	public static void loadConfig(String file) {
+		FileReader reader = null;
+		try {
+			reader = new FileReader(new File(file));
+			configuration.load(reader);
+		} catch (Exception e) {
+			System.out
+					.println("["
+							+ new Timestamp(new Date().getTime())
+							+ "] Linea inadecuada"
+							+ " en el archivo de configuracion: \""
+							+ ""
+							+ "\"."
+							+ "\n Los comentarios en el archivo de"
+							+ " configuracion deben estar indicados con el caracter '#' al inicio.");
+		} finally {
+			try {
+				if (null != reader) {
+					reader.close();
 				}
-				temp = br.readLine();
+			} catch (Exception e2) {
+				e2.printStackTrace();
 			}
-		} catch (Exception e) { System.out.println("["+new Timestamp(new Date().getTime())+"] Linea inadecuada" +
-				" en el archivo de configuracion: \""+ temp +"\"." +
-				"\n Los comentarios en el archivo de" +
-				" configuracion deben estar indicados con el caracter '#' al inicio.");}
-		finally
-		{
-			try                  {if (null != fr) fr.close();}
-			catch (Exception e2) { e2.printStackTrace();}
+		}
+		
+		postProcessConfig ();
+	}
+	/**
+	 * Post-procesa el archivo de configuración:
+	 * - Descomprime los archivos zip de catastro si están comprimidos.
+	 * - Obtiene el sistema de coordenadas de los shapes leyendo de sus prj.
+	 * - Descarga la rejilla si no está descargada y está en modmo auto.
+	 * 
+	 */
+	private static void postProcessConfig() {
+		createDirAtHome();
+		normalizeVariableContent("UrbanoSHPPath");
+		normalizeVariableContent("RusticoSHPPath");
+		try {
+			CatExtractor.extract(Config.get("UrbanoSHPPath"));
+			CatExtractor.extract(Config.get("RusticoSHPPath"));
+		}
+		catch (IOException ioe){
+			ioe.printStackTrace();
+		}
+		String proyeccion = configuration.getProperty("Proyeccion", "");
+		String directorio = Config.get("UrbanoSHPPath");
+		if (StringUtils.isBlank(directorio)){
+			directorio = Config.get("RusticoSHPPath");
+		}		
+		if (!StringUtils.isBlank(directorio) && (StringUtils.isBlank(proyeccion) || "auto".equals(proyeccion))){
+			configuration.setProperty(
+				"Proyeccion", 
+				CatProjectionReader.autodetectProjection(directorio)
+			);
+		}
+		configureGrid();
+	}
+	/** 
+	 * Crea un directorio para catosm (".catosm") en el directorio del usuario.
+	 * En este directorio se guardarán los archivos de rejilla.
+	 */
+	private static void createDirAtHome() {
+		File directorioCatOsm = new File(System.getProperty("user.home") + File.separator + ".cat2osm");
+		directorioCatOsm.mkdirs();
+		configuration.setProperty("home", directorioCatOsm.getAbsolutePath());
+	}
+	/**
+	 * Elimina la extensión zip del nombre de archivo de shp de catastro.
+	 * Para usar en el resto del programa el directorio en lugar del zip
+	 * @param varName
+	 */
+	private static void normalizeVariableContent(String varName) {
+		String value = Config.get(varName);
+		if (value != null && value.toLowerCase().endsWith(".zip")){
+			Config.set(varName, value.replaceFirst("\\.[Zz][Ii][Pp]$", ""));
+		}
+	}
+	/**
+	 * Cambia la configuración de la rejilla si está en modo auto.
+	 * Si es necesario, descarga la rejilla de http://www.01.ign.es/ign/resources/herramientas/
+	 * y lo descarga en ${home}/.catosm/
+	 */
+	private static void configureGrid() {
+		String rejilla = configuration.getProperty("NadgridsPath");
+		if (StringUtils.isBlank(rejilla)){
+			rejilla = "auto:peninsula";
+		}
+		if (!rejilla.startsWith("auto")){
+			return;
+		}
+		File homeDir = new File(System.getProperty("user.home") + File.separator + ".cat2osm");
+		File archivoRejilla = null;
+		String url = "";
+		if ("auto:peninsula".equals(rejilla)){
+			url = "http://www.01.ign.es/ign/resources/herramientas/PENR2009.zip";
+			archivoRejilla = new File(homeDir, "peninsula.gsb");
+		}
+		else if ("auto:baleares".equals(rejilla)){
+			url = "http://www.01.ign.es/ign/resources/herramientas/BALR2009.zip";
+			archivoRejilla = new File(homeDir, "baleares.gsb");
+		}		
+		configuration.setProperty("NadgridsPath", archivoRejilla.getAbsolutePath());
+		downloadGrid(url, archivoRejilla);
+	}
+	/**
+	 * Descarga el archivo de rejilla y lo descomprime.
+	 * @param url
+	 * @param destino
+	 */
+	private static void downloadGrid(String url, File destino) {
+		if (destino.exists()) {
+			return;
+		}
+		try {
+			File temporal = File.createTempFile("cat2osm", "tmp.zip");
+			System.out.println("["+new Timestamp(new Date().getTime())+"] Descargando rejilla "+url);
+			URL descarga = new URL(url);
+			InputStream inputStream = descarga.openStream();
+			OutputStream outputStream = new FileOutputStream(temporal);
+			IOUtils.copy(inputStream, outputStream);
+			inputStream.close();
+			outputStream.close();
+			
+			ZipInputStream zis = new ZipInputStream(new FileInputStream(temporal));
+			zis.getNextEntry();
+			OutputStream outputStreamDestino = new FileOutputStream(destino);
+			IOUtils.copy(zis, outputStreamDestino);
+			zis.closeEntry();
+			zis.close();
+			outputStreamDestino.close();
+			temporal.delete();
+			
+		} catch (IOException e) {
+			e.printStackTrace();
 		}
 	}
 
-
-	/** Obtiene la opcion del hashMap de configuracion. Si no existe devuelve "".
+	/** Obtiene la opcion de configuracion. Si no existe devuelve "".
 	 *  @param option Opcion de configuracion a buscar.
 	 *  @param required Indica si la opción es obligatoria (true) u opcional (false).
 	 *  @return Valor que tiene en el hashMap o "". */
 	public static String get(String option, boolean required){
 		
-		if (map.get(option) == null && required)
+		if (configuration.get(option) == null && required){
 			System.out.println("["+new Timestamp(new Date().getTime())+"] No se ha encontrado el campo "+option+" en el archivo de configuración. Compruebe que existe o si no ejecute cat2osm con el parámetro -ui para crear un nuevo archivo de configuración.");
-		
-		return (map.get(option) == null) ? "" : map.get(option);
+		}
+		return configuration.getProperty(option, "");
 	}
 	
 	public static String get(String option) {
@@ -80,7 +185,7 @@ public class Config {
 	 * @param option Opcion a modificar.
 	 * @param value  Nuevo valor a poner. */
 	public static void set(String option, String value){ 
-		map.put(option,value);
+		configuration.put(option,value);
 	}
 	
 	
@@ -89,7 +194,7 @@ public class Config {
 	public static void set(List<String[]> l){
 
 		for (String[] s : l)
-			map.put(s[0], s[1]);
+			configuration.put(s[0], s[1]);
 	}
 
 }

--- a/src/Main.java
+++ b/src/Main.java
@@ -33,7 +33,7 @@ public class Main {
 		else if (args.length ==1 && new File(args[0]).exists()){
 			System.out.println("["+new Timestamp(new Date().getTime())+"] Iniciando Cat2Osm con el archivo de configuración " + args[0] + ".");
 			// Ruta al fichero de configuracion por parametro
-			new Config(args[0]);
+			Config.loadConfig(args[0]);
 			// Iniciar cat2osm
 			ejecutarCat2Osm("*");
 		}
@@ -49,14 +49,14 @@ public class Main {
 				&& new File(args[0]).exists()){
 			System.out.println("["+new Timestamp(new Date().getTime())+"] Iniciando Cat2Osm con el archivo de configuración para exportar únicamente "+ args[1].replaceAll("-", "").toUpperCase()+ ".");
 			// Ruta al fichero de configuracion por parametro
-			new Config(args[0]);
+			Config.loadConfig(args[0]);
 			// Iniciar cat2osm
 			ejecutarCat2Osm(args[1].replaceAll("-", "").toUpperCase());
 		}
 		else if (args.length == 2 && args[1].replaceAll("-", "").equals("usos") && new File(args[0]).exists()){
 			System.out.println("["+new Timestamp(new Date().getTime())+"] Iniciando Cat2Osm con el archivo de configuración para exportar únicamente el archivo de destinos a corregir.");
 			// Ruta al fichero de configuracion por parametro
-			new Config(args[0]);
+			Config.loadConfig(args[0]);
 			// Iniciar metodo de creacion de puntos de entrada
 			crearUsos();
 		}

--- a/src/Main.java
+++ b/src/Main.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.GZIPOutputStream;
 
 
 public class Main {
@@ -125,11 +126,12 @@ public class Main {
 		// Archivo global de resultado
 		// Borrar archivo con el mismo nombre si existe, porque sino concatenaria el nuevo
 		new File(Config.get("ResultPath") + "/" + Config.get("ResultFileName") + "/" + Config.get("ResultFileName") + ".osm").delete();
-
+		new File(Config.get("ResultPath") + "/" + Config.get("ResultFileName") + "/" + Config.get("ResultFileName") + ".osm.gz").delete();
+		
 		// Archivo al que se le concatenan todos los archivos de nodos, ways y relations
-		String fstreamOsm = Config.get("ResultPath") + "/" + Config.get("ResultFileName") + "/" + Config.get("ResultFileName") + ".osm";
+		String fstreamOsm = Config.get("ResultPath") + "/" + Config.get("ResultFileName") + "/" + Config.get("ResultFileName") + ".osm.gz";
 		// Indicamos que el archivo se codifique en UTF-8
-		BufferedWriter outOsmGlobal = new BufferedWriter( new OutputStreamWriter (new FileOutputStream(fstreamOsm), "UTF-8"));
+		BufferedWriter outOsmGlobal = new BufferedWriter( new OutputStreamWriter (new GZIPOutputStream(new FileOutputStream(fstreamOsm)), "UTF-8"));
 
 		// Cabecera del archivo
 		outOsmGlobal.write("<?xml version='1.0' encoding='UTF-8'?>");outOsmGlobal.newLine();


### PR DESCRIPTION
JOSM soporta de forma trasparante que los archivos osm estén comprimidos con gzip, con extensión ".osm.gz". 
Con esto se ahorra mucho espacio (se reduce entre a 1/10 o 1/20 parte de la versión sin comprimir) sin afectar de forma apreciable al rendimiento
